### PR TITLE
Add purl to .gitignore and implement string replacement tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 
 # Go workspace file
 go.work
+
+purl

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/catatsuy/purl
+
+go 1.22.1

--- a/main.go
+++ b/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+)
+
+func main() {
+	var replaceExpr string
+	flag.StringVar(&replaceExpr, "replace", "", `Replacement expression, e.g., "@search@replace@"`)
+	flag.Parse()
+
+	if flag.NArg() == 0 {
+		fmt.Println("Usage: toolname --replace \"@search@replace@\" filename")
+		os.Exit(1)
+	}
+	filePath := flag.Arg(0)
+
+	if len(replaceExpr) < 3 {
+		fmt.Println("Invalid replace expression format. Use \"@search@replace@\"")
+		os.Exit(1)
+	}
+
+	delimiter := string(replaceExpr[0])
+	parts := regexp.MustCompile(regexp.QuoteMeta(delimiter)).Split(replaceExpr[1:], -1)
+	if len(parts) < 2 {
+		fmt.Println("Invalid replace expression format. Use \"@search@replace@\"")
+		os.Exit(1)
+	}
+	searchPattern, replacement := parts[0], parts[1]
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		fmt.Printf("Failed to open file: %s\n", err)
+		os.Exit(1)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	re, err := regexp.Compile(searchPattern)
+	if err != nil {
+		fmt.Printf("Invalid regex pattern: %s\n", err)
+		os.Exit(1)
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		modifiedLine := re.ReplaceAllString(line, replacement)
+		fmt.Println(modifiedLine)
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Printf("Error reading file: %s\n", err)
+		os.Exit(1)
+	}
+}

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,4 @@
+-ab-axxb-
+-ab-axxb-
+-ab-axxb-
+-ab-axxb-


### PR DESCRIPTION
This pull request introduces a new Go module named `github.com/catatsuy/purl` and a command-line tool implemented in the `main.go` file. The tool accepts a file and a replacement expression as input, and it replaces all occurrences of the search pattern in the file with the replacement string. The changes also include a test file `test.txt` where some lines were removed.

New Go module:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R1-R3): Created a new Go module with the name `github.com/catatsuy/purl`.

New command-line tool:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R1-R59): Implemented a command-line tool that accepts a file and a replacement expression as input. The tool uses regular expressions to replace all occurrences of the search pattern in the file with the replacement string.

Test file changes:

* [`test.txt`](diffhunk://#diff-a6ed0c785d4590bc95c216bcf514384eee6765b1c2b732d0b0a1ad7e14d3204aR1-R4): Removed some lines from the file.