### PR TITLE
Add Makefile and CLI for purl command line tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: all
+all: bin/purl
+
+go.mod go.sum:
+	go mod tidy
+
+bin/purl: main.go cli/*.go
+	go build -o bin/purl main.go
+
+.PHONY: vet
+vet:
+	go vet ./...
+
+.PHONY: staticcheck
+staticcheck:
+	staticcheck -checks="all,-ST1000" ./...
+
+.PHONY: clean
+clean:
+	rm -rf bin/*

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+)
+
+const (
+	ExitCodeOK             = 0
+	ExitCodeParseFlagError = 1
+	ExitCodeFail           = 1
+)
+
+type CLI struct {
+	outStream, errStream io.Writer
+	inputStream          io.Reader
+}
+
+func NewCLI(outStream, errStream io.Writer, inputStream io.Reader) *CLI {
+	return &CLI{outStream: outStream, errStream: errStream, inputStream: inputStream}
+}
+
+func (c *CLI) Run(args []string) int {
+	flags := flag.NewFlagSet("notify_slack", flag.ContinueOnError)
+	flags.SetOutput(c.errStream)
+
+	var replaceExpr string
+
+	flags.StringVar(&replaceExpr, "replace", "", `Replacement expression, e.g., "@search@replace@"`+"\n")
+
+	err := flags.Parse(args[1:])
+	if err != nil {
+		return ExitCodeParseFlagError
+	}
+
+	if flags.NArg() == 0 {
+		fmt.Fprintf(c.errStream, "Usage: purl --replace \"@search@replace@\" filename\n")
+		return ExitCodeFail
+	}
+	filePath := flags.Arg(0)
+
+	if len(replaceExpr) < 3 {
+		fmt.Fprintf(c.errStream, "Invalid replace expression format. Use \"@search@replace@\"\n")
+		return ExitCodeFail
+	}
+
+	delimiter := string(replaceExpr[0])
+	parts := regexp.MustCompile(regexp.QuoteMeta(delimiter)).Split(replaceExpr[1:], -1)
+	if len(parts) < 2 {
+		fmt.Fprintf(c.errStream, "Invalid replace expression format. Use \"@search@replace@\"\n")
+		return ExitCodeFail
+	}
+	searchPattern, replacement := parts[0], parts[1]
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		fmt.Fprintf(c.errStream, "Failed to open file: %s\n", err)
+		return ExitCodeFail
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	re, err := regexp.Compile(searchPattern)
+	if err != nil {
+		fmt.Fprintf(c.errStream, "Invalid regex pattern: %s\n", err)
+		return ExitCodeFail
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		modifiedLine := re.ReplaceAllString(line, replacement)
+		fmt.Fprintf(c.outStream, modifiedLine+"\n")
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Printf("Error reading file: %s\n", err)
+		return ExitCodeFail
+	}
+
+	return ExitCodeOK
+}

--- a/main.go
+++ b/main.go
@@ -1,59 +1,12 @@
 package main
 
 import (
-	"bufio"
-	"flag"
-	"fmt"
 	"os"
-	"regexp"
+
+	"github.com/catatsuy/purl/cli"
 )
 
 func main() {
-	var replaceExpr string
-	flag.StringVar(&replaceExpr, "replace", "", `Replacement expression, e.g., "@search@replace@"`)
-	flag.Parse()
-
-	if flag.NArg() == 0 {
-		fmt.Println("Usage: toolname --replace \"@search@replace@\" filename")
-		os.Exit(1)
-	}
-	filePath := flag.Arg(0)
-
-	if len(replaceExpr) < 3 {
-		fmt.Println("Invalid replace expression format. Use \"@search@replace@\"")
-		os.Exit(1)
-	}
-
-	delimiter := string(replaceExpr[0])
-	parts := regexp.MustCompile(regexp.QuoteMeta(delimiter)).Split(replaceExpr[1:], -1)
-	if len(parts) < 2 {
-		fmt.Println("Invalid replace expression format. Use \"@search@replace@\"")
-		os.Exit(1)
-	}
-	searchPattern, replacement := parts[0], parts[1]
-
-	file, err := os.Open(filePath)
-	if err != nil {
-		fmt.Printf("Failed to open file: %s\n", err)
-		os.Exit(1)
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	re, err := regexp.Compile(searchPattern)
-	if err != nil {
-		fmt.Printf("Invalid regex pattern: %s\n", err)
-		os.Exit(1)
-	}
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		modifiedLine := re.ReplaceAllString(line, replacement)
-		fmt.Println(modifiedLine)
-	}
-
-	if err := scanner.Err(); err != nil {
-		fmt.Printf("Error reading file: %s\n", err)
-		os.Exit(1)
-	}
+	c := cli.NewCLI(os.Stdout, os.Stderr, os.Stdin)
+	os.Exit(c.Run(os.Args))
 }


### PR DESCRIPTION
This pull request includes significant changes to the codebase, primarily focused on refactoring and improving the build process. The most important changes include the addition of a `Makefile` to streamline the build process, the creation of a new `CLI` package to handle command-line interactions, and the simplification of `main.go` by moving most of its functionality to `cli/cli.go`.

Build process improvements:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R20): Added a new `Makefile` to automate the build process, including tasks for building the application, running static checks, and cleaning up build artifacts.

Codebase refactoring:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R1-R85): Created a new `CLI` package with a `CLI` struct and associated methods to handle command-line interactions, such as parsing flags and running the application. This change improves the modularity and testability of the code.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L4-R11): Simplified the `main` function by moving most of its functionality to `cli/cli.go`. The `main` function now simply creates a new `CLI` instance and runs the application. This change makes `main.go` cleaner and easier to understand.