### PR TITLE
Refactor CLI constructor and file handling logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/catatsuy/purl
 
 go 1.22.1
+
+require (
+	golang.org/x/sys v0.18.0 // indirect
+	golang.org/x/term v0.18.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
+golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
+golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=

--- a/main.go
+++ b/main.go
@@ -7,6 +7,6 @@ import (
 )
 
 func main() {
-	c := cli.NewCLI(os.Stdout, os.Stderr, os.Stdin)
+	c := cli.NewCLI(os.Stderr, os.Stdin)
 	os.Exit(c.Run(os.Args))
 }


### PR DESCRIPTION
This pull request introduces several changes to the `cli/cli.go` file in the `cli` package, primarily to enhance the functionality of the command-line interface (CLI) by adding an `inplaceEdit` option and improving the error handling. It also modifies the dependencies in the `go.mod` file and adjusts the `NewCLI` function call in the `main.go` file.

Enhancements to the CLI:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L23-L44): The `NewCLI` function has been modified to remove the `outStream` parameter. This function now only takes `errStream` and `inputStream` as parameters.
* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R70-R104): The `Run` function has been significantly modified to add an `inplaceEdit` option. This option allows the file to be overwritten in place. The function now also includes better error handling and more comprehensive user prompts. [[1]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R70-R104) [[2]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L80-R128)

Dependency and function call adjustments:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R4-R8): The Go dependencies have been updated to include `golang.org/x/sys` and `golang.org/x/term`.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L10-R10): The `NewCLI` function call has been adjusted to match the updated function definition.

Minor changes:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R10-R11): The `golang.org/x/term` package has been imported.