### PR TITLE
Add test for NewCLI function and CLI Run method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ vet:
 staticcheck:
 	staticcheck -checks="all,-ST1000" ./...
 
+.PHONY: test
+test:
+	go test -cover -v ./...
+
 .PHONY: clean
 clean:
 	rm -rf bin/*

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -22,8 +22,8 @@ type CLI struct {
 	inputStream          io.Reader
 }
 
-func NewCLI(errStream io.Writer, inputStream io.Reader) *CLI {
-	return &CLI{errStream: errStream, inputStream: inputStream}
+func NewCLI(outStream, errStream io.Writer, inputStream io.Reader) *CLI {
+	return &CLI{outStream: outStream, errStream: errStream, inputStream: inputStream}
 }
 
 func (c *CLI) Run(args []string) int {
@@ -83,8 +83,6 @@ func (c *CLI) Run(args []string) int {
 			fmt.Fprintf(c.errStream, "Failed to open file for writing: %s\n", err)
 			return ExitCodeFail
 		}
-	} else {
-		c.outStream = os.Stdout
 	}
 
 	if filePath != "" {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -7,10 +7,61 @@ import (
 	"github.com/catatsuy/purl/cli"
 )
 
+func TestNewCLI(t *testing.T) {
+	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
+	cl := cli.NewCLI(outStream, errStream, inputStream)
+
+	if cl == nil {
+		t.Error("NewCLI should not return nil")
+	}
+}
+
+func TestRun_success(t *testing.T) {
+	tests := map[string]struct {
+		args     []string
+		input    string
+		expected string
+		result   int
+	}{
+		"normal": {
+			args:     []string{"purl", "-replace", "@search@replacement@"},
+			input:    "searchb searchc",
+			expected: "replacementb replacementc\n",
+		},
+		"no match": {
+			args:     []string{"purl", "-replace", "@search@replacement@"},
+			input:    "no match",
+			expected: "no match\n",
+		},
+		"provide file": {
+			args:     []string{"purl", "-replace", "@search@replacement@", "testdata/test.txt"},
+			expected: "replacementa replacementb\n",
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
+			cl := cli.NewCLI(outStream, errStream, inputStream)
+			inputStream.WriteString(test.input)
+
+			expectedCode := 0
+			if got, expected := cl.Run(test.args), expectedCode; got != expected {
+				t.Fatalf("Expected exit code %d, but got %d; error: %q", expected, got, errStream.String())
+			}
+
+			if outStream.String() != test.expected {
+				t.Errorf("Output=%q, want %q; error: %q", outStream.String(), test.expected, errStream.String())
+			}
+		})
+	}
+}
+
 func TestProcessFiles_replace(t *testing.T) {
 	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
-	cl := cli.NewCLI(errStream, inputStream)
-	cl.SetOutputStream(outStream)
+	cl := cli.NewCLI(outStream, errStream, inputStream)
 
 	inputStream.WriteString("searchb searchc")
 
@@ -21,6 +72,24 @@ func TestProcessFiles_replace(t *testing.T) {
 	}
 
 	expected := "replacementb replacementc\n"
+	if outStream.String() != expected {
+		t.Errorf("Output=%q, want %q; error: %q", outStream.String(), expected, errStream.String())
+	}
+}
+
+func TestProcessFiles_noMatch(t *testing.T) {
+	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
+	cl := cli.NewCLI(outStream, errStream, inputStream)
+
+	inputStream.WriteString("no match")
+
+	err := cl.ProcessFiles("search", "replacement")
+
+	if err != nil {
+		t.Errorf("Error=%q", err)
+	}
+
+	expected := "no match\n"
 	if outStream.String() != expected {
 		t.Errorf("Output=%q, want %q; error: %q", outStream.String(), expected, errStream.String())
 	}

--- a/cli/export_test.go
+++ b/cli/export_test.go
@@ -1,11 +1,5 @@
 package cli
 
-import "io"
-
-func (c *CLI) SetOutputStream(outStream io.Writer) {
-	c.outStream = outStream
-}
-
 func (c *CLI) ProcessFiles(searchPattern string, replacement string) error {
 	return c.processFiles(searchPattern, replacement)
 }

--- a/cli/testdata/test.txt
+++ b/cli/testdata/test.txt
@@ -1,0 +1,1 @@
+searcha searchb

--- a/main.go
+++ b/main.go
@@ -7,6 +7,6 @@ import (
 )
 
 func main() {
-	c := cli.NewCLI(os.Stderr, os.Stdin)
+	c := cli.NewCLI(os.Stdout, os.Stderr, os.Stdin)
 	os.Exit(c.Run(os.Args))
 }


### PR DESCRIPTION
This pull request includes several changes to the `cli` package and `Makefile` to improve testing and output handling. The most significant changes include the addition of a `test` target in the `Makefile`, the modification of the `NewCLI` function to include an `outStream` parameter, and the addition of new test cases in `cli_test.go`.

Enhancements to the `Makefile`:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R18-R21): A `test` target was added to run tests with coverage and verbosity.

Changes to the `cli` package:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L25-R26): The `NewCLI` function was modified to include an `outStream` parameter, and the `Run` function was updated to remove the else block that sets `c.outStream` to `os.Stdout`. [[1]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L25-R26) [[2]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L86-L87)
* [`cli/cli_test.go`](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dR10-R64): New test cases were added to test the `NewCLI` function and the `Run` function. The `TestProcessFiles_replace` function was also updated to use the new `NewCLI` function. A new test case `TestProcessFiles_noMatch` was added. [[1]](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dR10-R64) [[2]](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dR79-R96)
* [`cli/export_test.go`](diffhunk://#diff-8b89ce90fe29b17021e8c3a68fce7032ba2224d85770cf99d14c30813094a16dL3-L8): The `SetOutputStream` function was removed.

Changes to other files:

* [`cli/testdata/test.txt`](diffhunk://#diff-7e790a173a377e0432f8d4fc8633d63f4fae78c36b243a0e8fdf4b8a2f6158c1R1): New test data was added.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L10-R10): The `NewCLI` function was updated to include `os.Stdout` as an argument.