### PR TITLE
Update error message formatting and output

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -45,24 +45,24 @@ func (c *CLI) Run(args []string) int {
 	if flags.NArg() > 0 {
 		filePath = flags.Arg(0)
 	} else if term.IsTerminal(int(os.Stdin.Fd())) {
-		fmt.Fprintf(c.errStream, "No input file specified\n")
+		fmt.Fprintln(c.errStream, "No input file specified")
 		return ExitCodeFail
 	}
 
 	if inplaceEdit && filePath == "" {
-		fmt.Fprintf(c.errStream, "Cannot use -i option with stdin\n")
+		fmt.Fprintln(c.errStream, "Cannot use -i option with stdin")
 		return ExitCodeFail
 	}
 
 	if len(replaceExpr) < 3 {
-		fmt.Fprintf(c.errStream, "Invalid replace expression format. Use \"@search@replace@\"\n")
+		fmt.Fprintln(c.errStream, "Invalid replace expression format. Use \"@search@replace@\"")
 		return ExitCodeFail
 	}
 
 	delimiter := string(replaceExpr[0])
 	parts := regexp.MustCompile(regexp.QuoteMeta(delimiter)).Split(replaceExpr[1:], -1)
 	if len(parts) < 2 {
-		fmt.Fprintf(c.errStream, "Invalid replace expression format. Use \"@search@replace@\"\n")
+		fmt.Fprintln(c.errStream, "Invalid replace expression format. Use \"@search@replace@\"")
 		return ExitCodeFail
 	}
 	searchPattern, replacement := parts[0], parts[1]
@@ -122,7 +122,7 @@ func (c *CLI) processFiles(searchPattern, replacement string) error {
 	for scanner.Scan() {
 		line := scanner.Text()
 		modifiedLine := re.ReplaceAllString(line, replacement)
-		fmt.Fprintf(c.outStream, modifiedLine+"\n")
+		fmt.Fprintln(c.outStream, modifiedLine)
 	}
 
 	if err := scanner.Err(); err != nil {


### PR DESCRIPTION
This pull request includes changes in the `cli/cli.go` file, specifically in the `Run` and `processFiles` methods of the `CLI` struct. The changes involve replacing the `fmt.Fprintf` function with `fmt.Fprintln` for outputting error messages and processed lines.

Here are the key changes:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L48-R65): In the `Run` method of the `CLI` struct, the `fmt.Fprintf` function was replaced with `fmt.Fprintln` for outputting error messages when no input file is specified, the `-i` option is used with stdin, and the replace expression format is invalid.
* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L125-R125): In the `processFiles` method of the `CLI` struct, the `fmt.Fprintf` function was replaced with `fmt.Fprintln` for outputting the modified line.

These changes simplify the code by using `fmt.Fprintln`, which automatically appends a newline to the output, instead of manually appending it with `fmt.Fprintf`.