### PR TITLE
Add test case for failing to provide stdin in Run method

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/catatsuy/purl/cli"
@@ -56,6 +57,16 @@ func TestRun_success(t *testing.T) {
 				t.Errorf("Output=%q, want %q; error: %q", outStream.String(), test.expected, errStream.String())
 			}
 		})
+	}
+}
+
+func TestRun_failToProvideStdin(t *testing.T) {
+	outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
+	cl := cli.NewCLI(outStream, errStream, os.Stdin)
+
+	expectedCode := 1
+	if got, expected := cl.Run([]string{"purl", "-replace", "@search@replacement@"}), expectedCode; got == expected {
+		t.Fatalf("Expected exit code %d, but got %d; error: %q", expected, got, errStream.String())
 	}
 }
 


### PR DESCRIPTION
This pull request introduces changes to the `cli/cli_test.go` file in the `cli_test` package. The key changes include the import of the `os` package and the addition of a new test function `TestRun_failToProvideStdin`.

Here are the main changes in detail:

* [`cli/cli_test.go`](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dR5): Imported the `os` package. This package provides a platform-independent interface to operating system functionality and is typically used for tasks such as reading environment variables or command-line arguments, or interacting with the file system.
* [`cli/cli_test.go`](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dR63-R72): Added a new test function `TestRun_failToProvideStdin`. This function tests the scenario where the `Run` method fails due to the absence of standard input. It creates a new instance of `CLI` with `os.Stdin` as the input stream, runs the `Run` method with a specific command, and checks if the exit code matches the expected value. If the exit code does not match, it fails the test and prints an error message with the expected and actual exit codes and the error message from the error stream.