### PR TITLE
Add filter option

### DIFF
--- a/cli/export_test.go
+++ b/cli/export_test.go
@@ -1,5 +1,15 @@
 package cli
 
+import "regexp"
+
 func (c *CLI) ReplaceProcess(searchPattern string, replacement string) error {
 	return c.replaceProcess(searchPattern, replacement)
+}
+
+func (c *CLI) FilterProcess(regexps []*regexp.Regexp) error {
+	return c.filterProcess(regexps)
+}
+
+func CompileRegexps(rawPatterns []string) ([]*regexp.Regexp, error) {
+	return compileRegexps(rawPatterns)
 }


### PR DESCRIPTION
This pull request to `cli/cli.go` introduces a new feature that allows the user to filter input using regular expressions. The changes include the addition of a new `rawStrings` type and related methods, the modification of the `Run` method to handle the new `filter` command-line option, and the creation of new methods to process the filter and compile regular expressions.

New feature:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R20-R30): Introduced a new `rawStrings` type and related methods to handle multiple string arguments from the command line.

Command-line interface changes:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R46-R50): Modified the `Run` method to include a new `filter` command-line option, and updated the error handling to prevent the use of `replace` and `filter` options together. [[1]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R46-R50) [[2]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L57-R75)

New methods:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R168-R200): Added new methods `filterProcess` and `compileRegexps` for processing the filter and compiling regular expressions, respectively. The `filterProcess` method reads from the input stream, checks each line against the provided regular expressions, and writes matching lines to the output stream. The `compileRegexps` method compiles the regular expressions provided as raw strings.

Changes to existing methods:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R109): Updated the `Run` method to call the new `filterProcess` method when the `filter` option is used, and to call the existing `replaceProcess` method only when the `replace` option is used. [[1]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R109) [[2]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R122-R136)