### PR TITLE
Refactor file processing function naming for clarity

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -76,7 +76,7 @@ func TestProcessFiles_replace(t *testing.T) {
 
 	inputStream.WriteString("searchb searchc")
 
-	err := cl.ProcessFiles("search", "replacement")
+	err := cl.ReplaceProcess("search", "replacement")
 
 	if err != nil {
 		t.Errorf("Error=%q", err)
@@ -94,7 +94,7 @@ func TestProcessFiles_noMatch(t *testing.T) {
 
 	inputStream.WriteString("no match")
 
-	err := cl.ProcessFiles("search", "replacement")
+	err := cl.ReplaceProcess("search", "replacement")
 
 	if err != nil {
 		t.Errorf("Error=%q", err)

--- a/cli/export_test.go
+++ b/cli/export_test.go
@@ -1,5 +1,5 @@
 package cli
 
-func (c *CLI) ProcessFiles(searchPattern string, replacement string) error {
-	return c.processFiles(searchPattern, replacement)
+func (c *CLI) ReplaceProcess(searchPattern string, replacement string) error {
+	return c.replaceProcess(searchPattern, replacement)
 }


### PR DESCRIPTION
This pull request primarily refactors the `cli/cli.go` file, specifically the `Run` method, to improve error handling and streamline the file opening process. Additionally, the `processFiles` method is renamed to `replaceProcess` and corresponding changes are made in the test files.

Here are the most important changes:

Refactoring of `Run` method:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L53-R53): The error message for the `-overwrite` option has been updated for clarity.
* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L62-R71): The file opening process has been moved up in the `Run` method to occur before the delimiter and replace expression handling. This change improves error handling by exiting the function early if the file fails to open.
* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L88-R99): The delimiter and replace expression handling has been moved down in the `Run` method, after the file opening process. This change streamlines the code and improves readability.

Renaming of `processFiles` method:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L114-R114): The `processFiles` method has been renamed to `replaceProcess` to better reflect its functionality.
* [`cli/cli_test.go`](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL79-R79): The method calls in the `TestProcessFiles_replace` and `TestProcessFiles_noMatch` tests have been updated to reflect the new method name. [[1]](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL79-R79) [[2]](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL97-R97)
* [`cli/export_test.go`](diffhunk://#diff-8b89ce90fe29b17021e8c3a68fce7032ba2224d85770cf99d14c30813094a16dL3-R4): The exported function has been updated to reflect the new method name.