### PR TITLE
Update test function names for processing files

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -70,7 +70,7 @@ func TestRun_failToProvideStdin(t *testing.T) {
 	}
 }
 
-func TestProcessFiles_replace(t *testing.T) {
+func TestReplaceProcess_replace(t *testing.T) {
 	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
 	cl := cli.NewCLI(outStream, errStream, inputStream)
 
@@ -88,7 +88,7 @@ func TestProcessFiles_replace(t *testing.T) {
 	}
 }
 
-func TestProcessFiles_noMatch(t *testing.T) {
+func TestReplaceProcess_noMatch(t *testing.T) {
 	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
 	cl := cli.NewCLI(outStream, errStream, inputStream)
 


### PR DESCRIPTION
This pull request includes changes to the `cli/cli_test.go` file, specifically renaming test functions to better reflect the processes they are testing. 

The changes are as follows:

* [`func TestProcessFiles_replace(t *testing.T) {`](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL73-R73): Renamed this function to `func TestReplaceProcess_replace(t *testing.T) {` to better describe that it's testing the replace process.
* [`func TestProcessFiles_noMatch(t *testing.T) {`](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL91-R91): Renamed this function to `func TestReplaceProcess_noMatch(t *testing.T) {` to clarify that it's testing the scenario where the replace process finds no match.