### PR TITLE
Add help option to display usage info

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -36,6 +36,7 @@ type CLI struct {
 	replaceExpr string
 	isOverwrite bool
 	filters     rawStrings
+	help        bool
 }
 
 func NewCLI(outStream, errStream io.Writer, inputStream io.Reader) *CLI {
@@ -47,6 +48,11 @@ func (c *CLI) Run(args []string) int {
 	if err != nil {
 		fmt.Fprintf(c.errStream, "Failed to parse flags: %s\n", err)
 		return ExitCodeParseFlagError
+	}
+
+	if c.help {
+		flags.Usage()
+		return ExitCodeOK
 	}
 
 	err = c.validateInput(flags)
@@ -130,6 +136,12 @@ func (c *CLI) parseFlags(args []string) (*flag.FlagSet, error) {
 	flags.BoolVar(&c.isOverwrite, "overwrite", false, "overwrite the file in place")
 	flags.StringVar(&c.replaceExpr, "replace", "", `Replacement expression, e.g., "@search@replace@"`)
 	flags.Var(&c.filters, "filter", `Filter expression`)
+	flags.BoolVar(&c.help, "help", false, `Show help`)
+
+	flags.Usage = func() {
+		fmt.Fprintln(c.errStream, "Usage: purl [options] [file]")
+		flags.PrintDefaults()
+	}
 
 	err := flags.Parse(args[1:])
 	if err != nil {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -60,6 +60,32 @@ func TestRun_success(t *testing.T) {
 	}
 }
 
+func TestRun_help(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		args         []string
+		expectedCode int
+	}{
+		{
+			desc:         "help option",
+			args:         []string{"purl", "-help"},
+			expectedCode: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
+			cl := cli.NewCLI(outStream, errStream, os.Stdin)
+
+			if got := cl.Run(tc.args); got != tc.expectedCode {
+				t.Fatalf("Expected exit code %d, but got %d; error: %q", tc.expectedCode, got, errStream.String())
+			}
+		})
+	}
+}
+
 func TestRun_failToProvideStdin(t *testing.T) {
 	testCases := []struct {
 		desc         string


### PR DESCRIPTION
This pull request introduces a help functionality to the CLI struct in the `cli/cli.go` file. The `help` field was added to the CLI struct, and the `Run` and `parseFlags` methods were updated to handle the help flag. A test case for the help functionality was also added to `cli/cli_test.go`.

Here are the most important changes:

Addition of help functionality:

* `cli/cli.go` (in the `type CLI struct`): Added a `help` boolean field to the CLI struct.
* `cli/cli.go` (in the `func (c *CLI) Run(args []string) int`): Updated the `Run` method to check if the `help` flag is set. If it is, the usage of the CLI is printed and the function returns with an exit code of OK.
* `cli/cli.go` (in the `func (c *CLI) parseFlags(args []string) (*flag.FlagSet, error)`): Updated the `parseFlags` method to handle the `help` flag. If the `help` flag is set, the usage of the CLI is printed.

Addition of test case:

* `cli/cli_test.go` (in the `func TestRun_success(t *testing.T)`): Added a test case for the help functionality. The test case checks if the CLI returns the correct exit code when the `help` flag is set.