### PR TITLE
Update filter process to handle not-filter expressions

### DIFF
--- a/cli/export_test.go
+++ b/cli/export_test.go
@@ -6,8 +6,8 @@ func (c *CLI) ReplaceProcess(searchPattern string, replacement string) error {
 	return c.replaceProcess(searchPattern, replacement)
 }
 
-func (c *CLI) FilterProcess(regexps []*regexp.Regexp) error {
-	return c.filterProcess(regexps)
+func (c *CLI) FilterProcess(filters []*regexp.Regexp, notFilters []*regexp.Regexp) error {
+	return c.filterProcess(filters, notFilters)
 }
 
 func CompileRegexps(rawPatterns []string) ([]*regexp.Regexp, error) {


### PR DESCRIPTION
This pull request primarily introduces a new feature to the `CLI` struct in the `cli/cli.go` file, which allows the user to specify not only filters but also not-filters when running the CLI. This new feature is reflected in the `Run`, `parseFlags`, `validateInput`, and `filterProcess` functions. Additionally, a helper function `matchesFilters` was added to handle the filter matching logic. The test files `cli/cli_test.go` and `cli/export_test.go` were updated to reflect these changes and to ensure the new feature works as expected.

### New Feature: Not-Filters
* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R39): Added a new member `notFilters` to the `CLI` struct. Modified the `Run`, `parseFlags`, `validateInput`, and `filterProcess` functions to handle the new `notFilters` feature. Added a new helper function `matchesFilters` to handle the filter matching logic. [[1]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R39) [[2]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L108-R122) [[3]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R146) [[4]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L163-R175) [[5]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L204-L214) [[6]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R240-R248)

### Test Updates:
* [`cli/cli_test.go`](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL20-R20): Renamed some test functions and added new test cases to cover the new not-filter feature. Modified the `TestFilterProcess` function to handle the new `filters` and `notFilters` parameters. [[1]](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL20-R20) [[2]](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL63-R63) [[3]](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dR74-R103) [[4]](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL217-R305) [[5]](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL253-R327)
* [`cli/export_test.go`](diffhunk://#diff-8b89ce90fe29b17021e8c3a68fce7032ba2224d85770cf99d14c30813094a16dL9-R10): Updated the `FilterProcess` function to handle the new `filters` and `notFilters` parameters.