### PR TITLE
Refactor filter process logic for CLI function

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -214,7 +214,7 @@ func (c *CLI) filterProcess(filters []*regexp.Regexp, notFilters []*regexp.Regex
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if matchesFilters(line, filters) || (len(notFilters) > 0 && !matchesFilters(line, notFilters)) {
+		if (len(filters) == 0 || matchesFilters(line, filters)) && !matchesFilters(line, notFilters) {
 			fmt.Fprintln(c.outStream, line)
 		}
 	}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -298,10 +298,10 @@ func TestFilterProcess(t *testing.T) {
 		},
 		{
 			name:       "provide filter and not filter",
-			input:      "apple\nbanana\ncherry\n",
+			input:      "apple\nbanana\napple cherry\ncherry\n",
 			filters:    []string{"apple"},
 			notFilters: []string{"cherry"},
-			wantOutput: "apple\nbanana\n",
+			wantOutput: "apple\n",
 		},
 	}
 


### PR DESCRIPTION
This pull request primarily focuses on refining the filter process in the `cli/cli.go` and `cli/cli_test.go` files. The most significant changes involve modifying the condition for filtering lines and updating the corresponding test case to reflect this change.

Here are the most important changes:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L217-R217): The condition in the `filterProcess` function has been updated. Previously, a line would be printed if it matched any of the filters or if it did not match any of the notFilters, even if there were no notFilters. The condition has been changed so that if there are no filters, all lines that do not match the notFilters will be printed.

* [`cli/cli_test.go`](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL301-R304): The test case `TestFilterProcess` has been updated to reflect the changes in the `filterProcess` function. The input and expected output have been changed in the test case named "provide filter and not filter".