### PR TITLE
Update CLI filters with excludes option

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -87,18 +87,18 @@ func TestRun_success(t *testing.T) {
 			expectedCode: 0,
 		},
 		{
-			desc:         "-not-filter",
-			args:         []string{"purl", "-not-filter", "not filter"},
+			desc:         "-exclude",
+			args:         []string{"purl", "-exclude", "not filter"},
 			expectedCode: 0,
 		},
 		{
-			desc:         "multiple -not-filter",
-			args:         []string{"purl", "-not-filter", "not filter", "-not-filter", "not filter2"},
+			desc:         "multiple -exclude",
+			args:         []string{"purl", "-exclude", "not filter", "-exclude", "not filter2"},
 			expectedCode: 0,
 		},
 		{
-			desc:         "provide -filter and -not-filter",
-			args:         []string{"purl", "-filter", "filter", "-not-filter", "not filter2"},
+			desc:         "provide -filter and -exclude",
+			args:         []string{"purl", "-filter", "filter", "-exclude", "not filter2"},
 			expectedCode: 0,
 		},
 	}
@@ -245,7 +245,7 @@ func TestFilterProcess(t *testing.T) {
 		name       string
 		input      string
 		filters    []string
-		notFilters []string
+		excludes   []string
 		wantOutput string
 	}{
 		{
@@ -273,34 +273,34 @@ func TestFilterProcess(t *testing.T) {
 			wantOutput: "",
 		},
 		{
-			name:       "-not-filter: SingleMatch",
+			name:       "-exclude: SingleMatch",
 			input:      "apple\nbanana\ncherry\n",
-			notFilters: []string{"banana"},
+			excludes:   []string{"banana"},
 			wantOutput: "apple\ncherry\n",
 		},
 		{
-			name:       "-not-filter: MultipleMatches",
+			name:       "-exclude: MultipleMatches",
 			input:      "apple\nbanana\ncherry\n",
-			notFilters: []string{"apple", "cherry"},
+			excludes:   []string{"apple", "cherry"},
 			wantOutput: "banana\n",
 		},
 		{
-			name:       "-not-filter: NoMatch",
+			name:       "-exclude: NoMatch",
 			input:      "apple\nbanana\ncherry\n",
-			notFilters: []string{"date"},
+			excludes:   []string{"date"},
 			wantOutput: "apple\nbanana\ncherry\n",
 		},
 		{
-			name:       "-not-filter: EmptyInput",
+			name:       "-exclude: EmptyInput",
 			input:      "",
-			notFilters: []string{"apple"},
+			excludes:   []string{"apple"},
 			wantOutput: "",
 		},
 		{
 			name:       "provide filter and not filter",
 			input:      "apple\nbanana\napple cherry\ncherry\n",
 			filters:    []string{"apple"},
-			notFilters: []string{"cherry"},
+			excludes:   []string{"cherry"},
 			wantOutput: "apple\n",
 		},
 	}
@@ -318,13 +318,13 @@ func TestFilterProcess(t *testing.T) {
 				return
 			}
 
-			notFilters, err := cli.CompileRegexps(tt.notFilters)
+			excludes, err := cli.CompileRegexps(tt.excludes)
 			if err != nil {
 				t.Errorf("CompileRegexps() error = %v", err)
 				return
 			}
 
-			err = cl.FilterProcess(filters, notFilters)
+			err = cl.FilterProcess(filters, excludes)
 			if err != nil {
 				t.Errorf("filterProcess() error = %v", err)
 				return


### PR DESCRIPTION
This pull request includes changes in the `cli/cli.go` and `cli/cli_test.go` files. The changes mainly revolve around renaming the `notFilters` member of the `CLI` struct to `excludes`. This renaming has been propagated throughout the codebase, affecting several methods and their corresponding tests.

Here are the most important changes:

Renaming `notFilters` to `excludes`:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L39-R39): The `notFilters` member in the `CLI` struct has been renamed to `excludes`. This change affects the `Run`, `parseFlags`, `validateInput`, and `filterProcess` methods, where all instances of `notFilters` have been replaced with `excludes`. [[1]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L39-R39) [[2]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L109-R122) [[3]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L145-R146) [[4]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L171-R175) [[5]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L212-R217)

Updating the tests:

* [`cli/cli_test.go`](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL90-R101): All test cases that used the `-not-filter` flag have been updated to use the `-exclude` flag. This includes changes in `TestRun_success` and `TestFilterProcess`. [[1]](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL90-R101) [[2]](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL248-R248) [[3]](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL276-R303) [[4]](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL321-R327)