### PR TITLE
Add color option to CLI flags for output styling

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -38,6 +38,11 @@ func TestRun_successProcess(t *testing.T) {
 			args:     []string{"purl", "-replace", "@search@replacement@", "testdata/test.txt"},
 			expected: "replacementa replacementb\n",
 		},
+		"color text": {
+			args:     []string{"purl", "-filter", "search", "-color"},
+			input:    "searchb searchc",
+			expected: "\x1b[1m\x1b[91msearch\x1b[0mb \x1b[1m\x1b[91msearch\x1b[0mc\n",
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
This pull request mainly introduces colorized output to the CLI in the `cli/cli.go` file. It adds a new boolean field `color` to the `CLI` struct, a new command-line flag `-color` to control the color output, and modifies the `matchesFilters` function to return the matched regular expression. It also updates the `filterProcess` function to colorize the output line if the `-color` flag is set or if the output is a terminal. Additionally, a new function `colorText` is introduced to colorize the matched text, and a new test case is added in `cli/cli_test.go` to verify the color output.

Here are the major changes:

* `cli/cli.go`:
  * Added a new boolean field `color` to the `CLI` struct to control the color output.
  * Added a new command-line flag `-color` in the `parseFlags` function.
  * Modified the `filterProcess` function to colorize the output line if the `-color` flag is set or if the output is a terminal.
  * Modified the `matchesFilters` function to return the matched regular expression.
  * Introduced a new function `colorText` to colorize the matched text.

* `cli/cli_test.go`:
  * Added a new test case in `TestRun_successProcess` to verify the color output.