### PR TITLE
Add option to disable color output

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -40,8 +40,13 @@ func TestRun_successProcess(t *testing.T) {
 		},
 		"color text": {
 			args:     []string{"purl", "-filter", "search", "-color"},
-			input:    "searchb searchc",
-			expected: "\x1b[1m\x1b[91msearch\x1b[0mb \x1b[1m\x1b[91msearch\x1b[0mc\n",
+			input:    "searchb\nreplace\nsearchc",
+			expected: "\x1b[1m\x1b[91msearch\x1b[0mb\n\x1b[1m\x1b[91msearch\x1b[0mc\n",
+		},
+		"no color text": {
+			args:     []string{"purl", "-filter", "search", "-no-color"},
+			input:    "searchb\nreplace\nsearchc",
+			expected: "searchb\nsearchc\n",
 		},
 	}
 


### PR DESCRIPTION
This pull request primarily focuses on improving the color output functionality in the CLI tool. The changes include the introduction of a new command-line flag to disable colorized output, a modification to the color output logic, and updates to the test cases to reflect these changes.

Addition of new command-line flag:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R144-R151): A new `no-color` flag was added to the `parseFlags` function. This flag allows users to disable colorized output.

Modification to color output logic:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R164-R165): The logic for setting the `color` property was updated in the `parseFlags` function. Now, the `color` property is set to true only if the `no-color` flag is not set and either the `color` flag is set or the output is a terminal.
* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L222-R227): The condition for colorizing the text in the `filterProcess` function was simplified. Now, the text is colorized only if the `color` property is set to true.

Update to test cases:

* [`cli/cli_test.go`](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dL43-R49): The test case "color text" was updated to reflect the changes in the color output logic. A new test case "no color text" was added to test the `no-color` flag.