### PR TITLE
Add version option to display app version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ all: bin/purl
 go.mod go.sum:
 	go mod tidy
 
-bin/purl: main.go cli/*.go
-	go build -o bin/purl main.go
+bin/purl: main.go cli/*.go go.mod go.sum
+	go build -ldflags "-X github.com/catatsuy/purl/cli.Version=`git rev-list HEAD -n1`" -o bin/purl main.go
 
 .PHONY: vet
 vet:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Purl is a versatile text processing tool designed to easily and efficiently modi
 - **`-replace`**: This option requires a replacement expression to specify the text you intend to change. Format your command as "@search@replace@", with "search" being the text to find and "replace" the text to insert.
 - **`-color`** and **`-no-color`**: By default, Purl's output colorization is set to auto, determining the best mode based on your environment. Use `-no-color` if you prefer the output without colorization, regardless of the environment.
 - **`-help`**: Display information about Purl and its various options.
+- **`-version`**: Display version.
 
 ## Usage Examples
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -82,6 +82,11 @@ func TestRun_success(t *testing.T) {
 			expectedCode: 0,
 		},
 		{
+			desc:         "version option",
+			args:         []string{"purl", "-version"},
+			expectedCode: 0,
+		},
+		{
 			desc:         "filter",
 			args:         []string{"purl", "-filter", "search"},
 			expectedCode: 0,


### PR DESCRIPTION
This pull request primarily introduces a versioning feature to the `purl` command-line tool, which is a versatile text processing tool. The changes include the addition of a `-version` flag to display the version of the tool, the inclusion of build information in the version output, and updates to the build process to incorporate versioning information. The changes also include the necessary modifications to the test suite to accommodate the new versioning feature.

Here are the most important changes:

Versioning feature:

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R10-R11): Introduced a `version` function that retrieves the build information if available, otherwise defaults to "(devel)". Added a `Version` variable and an `appVersion` field to the `CLI` struct. Modified the `NewCLI` function to initialize `appVersion` with the version information. Added a condition in the `Run` method to check for the `-version` flag and print the version information if the flag is set. [[1]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R10-R11) [[2]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R22-R37) [[3]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R60-R66) [[4]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R76-R80)

* [`cli/cli.go`](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6R179-R182): Updated the `parseFlags` function to include a `-version` flag. Modified the usage message to include the version information.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19): Updated the documentation to include the `-version` flag.

Build process:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L7-R8): Modified the `bin/purl` target to include `go.mod` and `go.sum` as dependencies and to include versioning information in the build flags.

Test suite:

* [`cli/cli_test.go`](diffhunk://#diff-9b4bb0842b486c4e5cc8995a96e409c9cae71bdaa96c00a9df80cebf0446a40dR84-R88): Added a test case for the `-version` flag.