### PR TITLE
Update file path variable to hold multiple file paths

### DIFF
--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -1,13 +1,16 @@
 package cli
 
-import "regexp"
+import (
+	"io"
+	"regexp"
+)
 
-func (c *CLI) ReplaceProcess(searchPattern string, replacement string) error {
-	return c.replaceProcess(searchPattern, replacement)
+func (c *CLI) ReplaceProcess(searchPattern string, replacement string, inputStream io.Reader) error {
+	return c.replaceProcess(searchPattern, replacement, inputStream)
 }
 
-func (c *CLI) FilterProcess(filters []*regexp.Regexp, notFilters []*regexp.Regexp) error {
-	return c.filterProcess(filters, notFilters)
+func (c *CLI) FilterProcess(filters []*regexp.Regexp, notFilters []*regexp.Regexp, inputStream io.Reader) error {
+	return c.filterProcess(filters, notFilters, inputStream)
 }
 
 func CompileRegexps(rawPatterns []string) ([]*regexp.Regexp, error) {

--- a/internal/cli/testdata/testa.txt
+++ b/internal/cli/testdata/testa.txt
@@ -1,0 +1,2 @@
+searchc searchd
+not not not


### PR DESCRIPTION
This pull request primarily focuses on enhancing the functionality of the command-line interface (CLI) in the `internal/cli/cli.go` file. The changes enable the CLI to handle multiple files instead of a single file. This is achieved by modifying the `CLI` struct and several functions within it, including `Run`, `validateInput`, `replaceProcess`, and `filterProcess`. The `cli_test.go` file has also been updated to test the new functionality, and a new test file `testdata/testa.txt` has been added.

Changes to `CLI` struct and functions:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL53-R53): Updated the `CLI` struct to replace the `filePath` string field with a `filePaths` slice of strings, allowing multiple files to be processed.
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL92-L102): Modified the `Run` function to iterate over the `filePaths` slice and process each file. Additional code was added to handle the case when no file paths are provided. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL92-L102) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL130-R129) [[3]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL149-R197)
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL217-R265): The `validateInput` function was updated to validate each file path in the `filePaths` slice.
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL246-R286): The `replaceProcess` and `filterProcess` functions were modified to accept an `io.Reader` parameter, which is used to read from the file being processed.

Test updates:

* [`internal/cli/cli_test.go`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR41-R48): Added new test cases in `TestRun_successProcess` to test the processing of multiple files.
* [`internal/cli/cli_test.go`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR183-R251): Added a new test function `TestRun_failToProvideFiles` to test scenarios where file provision fails.
* [`internal/cli/cli_test.go`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL199-R269): Updated existing test functions to pass an `io.Reader` parameter when calling `ReplaceProcess` and `FilterProcess`. [[1]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL199-R269) [[2]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL342-R412)

Additional changes:

* [`internal/cli/export_test.go`](diffhunk://#diff-00cc0f11ec46bafc7c5c73ed3d347ca03a5e4c53f376353c9df449523b7f35d5L3-R13): Updated the exported `ReplaceProcess` and `FilterProcess` functions to accept an `io.Reader` parameter.
* [`internal/cli/testdata/testa.txt`](diffhunk://#diff-9eea75b9e863fa90654f5fac5d4befc6b141c738dbaafa6bdcb9beac4635f43fR1-R2): Added a new test file for testing the processing of multiple files.