### PR TITLE
Add test for overwriting file in Run function

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -107,8 +107,8 @@ func (c *CLI) Run(args []string) int {
 					fmt.Fprintf(c.errStream, "Failed to create temp file: %s\n", err)
 					return ExitCodeFail
 				}
-				defer tmpFile.Close()
 				defer os.Remove(tmpFile.Name())
+				defer tmpFile.Close()
 
 				c.outStream, err = os.Create(tmpFile.Name())
 				if err != nil {

--- a/internal/cli/testdata/test_for_overwrite.txt
+++ b/internal/cli/testdata/test_for_overwrite.txt
@@ -1,0 +1,2 @@
+searche searchf
+not not not


### PR DESCRIPTION
This pull request includes changes to the CLI and its tests in the `internal/cli` package, as well as an update to a test data file. The most significant changes include a minor adjustment to the order of `defer` statements in the `Run` method, the addition of a new test case `TestRun_successForOverwrite`, and an update to the `test_for_overwrite.txt` test data file.

Here are the most important changes, grouped by theme:

Order adjustment in CLI:
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL110-R111): The order of `defer` statements in the `Run` method was changed. The `os.Remove` call is now placed before the `tmpFile.Close` call. This change ensures that the temporary file is removed even if closing the file fails.

Addition of new test case:
* [`internal/cli/cli_test.go`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR142-R209): A new test case `TestRun_successForOverwrite` was added. This test case includes several subtests that verify the behavior of the `-overwrite`, `-replace`, and `-filter` options. A helper function `copyFile` was also added to assist with test setup.

Update to test data file:
* [`internal/cli/testdata/test_for_overwrite.txt`](diffhunk://#diff-a553342acf304514da435d6916e7cd673c8600058b1307eb5022990d082957c3R1-R2): The test data file was updated with new content. This change is likely related to the new `TestRun_successForOverwrite` test case.