### PR TITLE
Add ignore case functionality for search patterns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ staticcheck:
 test:
 	go test -cover -v ./...
 
+.PHONY: cover
+cover:
+	go test -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out
+
 .PHONY: clean
 clean:
 	rm -rf bin/*

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -13,6 +13,6 @@ func (c *CLI) FilterProcess(filters []*regexp.Regexp, notFilters []*regexp.Regex
 	return c.filterProcess(filters, notFilters, inputStream)
 }
 
-func CompileRegexps(rawPatterns []string) ([]*regexp.Regexp, error) {
-	return compileRegexps(rawPatterns)
+func CompileRegexps(rawPatterns []string, ignoreCase bool) ([]*regexp.Regexp, error) {
+	return compileRegexps(rawPatterns, ignoreCase)
 }

--- a/internal/cli/testdata/test.txt
+++ b/internal/cli/testdata/test.txt
@@ -1,1 +1,2 @@
 searcha searchb
+Searcha Searchb


### PR DESCRIPTION
This pull request primarily introduces the 'ignore case' feature to the CLI application, allowing users to ignore case sensitivity in regular expressions. It also adds a new 'cover' target to the Makefile to generate a coverage report. 

Here are the most important changes:

Addition of 'ignore case' feature:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR60): Added a new `ignoreCase` field to the `CLI` struct [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR60). This field is used to determine whether to ignore case sensitivity in regular expressions. The `Run` and `parseFlags` methods were updated to accommodate this new field [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR130-R147) [[3]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR177-R194) [[4]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR223). The `compileRegexps` function was also modified to prefix all regular expressions with `(?i)` if `ignoreCase` is true [[5]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL308-R323).
* [`internal/cli/cli_test.go`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL39-R56): Updated the tests to check the 'ignore case' feature. New test cases were added to `TestRun_successProcess` and `TestCompileRegexps` to test the functionality of the 'ignore case' feature [[1]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL39-R56) [[2]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR366-R379) [[3]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL379-R399). The `TestFilterProcess` test was updated to use the new `compileRegexps` function signature [[4]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL468-R494).
* [`internal/cli/export_test.go`](diffhunk://#diff-00cc0f11ec46bafc7c5c73ed3d347ca03a5e4c53f376353c9df449523b7f35d5L16-R17): Updated the `CompileRegexps` function to use the new `compileRegexps` function signature.

Addition of 'cover' target in Makefile:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R22-R26): Added a new 'cover' target that generates a coverage report using `go test -coverprofile` and `go tool cover -html`.

Test data changes:

* [`internal/cli/testdata/test.txt`](diffhunk://#diff-eabf01f348b36db377f1ac8dca2cf91cf2c84525ddb2c7bd9105d9525c66b566R2): Added a new line with different casing to test the 'ignore case' feature.