### PR TITLE
Refactor replaceProcess to use searchRe in replace logic

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/catatsuy/purl/internal/cli"
@@ -329,7 +330,7 @@ func TestReplaceProcess_replace(t *testing.T) {
 
 	inputStream.WriteString("searchb searchc")
 
-	err := cl.ReplaceProcess("search", "replacement", inputStream)
+	err := cl.ReplaceProcess(regexp.MustCompile("search"), "replacement", inputStream)
 
 	if err != nil {
 		t.Errorf("Error=%q", err)
@@ -347,7 +348,7 @@ func TestReplaceProcess_noMatch(t *testing.T) {
 
 	inputStream.WriteString("no match")
 
-	err := cl.ReplaceProcess("search", "replacement", inputStream)
+	err := cl.ReplaceProcess(regexp.MustCompile("search"), "replacement", inputStream)
 
 	if err != nil {
 		t.Errorf("Error=%q", err)

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 )
 
-func (c *CLI) ReplaceProcess(searchPattern string, replacement string, inputStream io.Reader) error {
-	return c.replaceProcess(searchPattern, replacement, inputStream)
+func (c *CLI) ReplaceProcess(searchRe *regexp.Regexp, replacement string, inputStream io.Reader) error {
+	return c.replaceProcess(searchRe, replacement, inputStream)
 }
 
 func (c *CLI) FilterProcess(filters []*regexp.Regexp, notFilters []*regexp.Regexp, inputStream io.Reader) error {


### PR DESCRIPTION
This pull request focuses on refactoring the `replaceProcess` and `filterProcess` methods in the `internal/cli/cli.go` file to improve the code readability and efficiency. The changes include the extraction of regex compilation logic from the methods and the adjustment of the methods' parameters to directly receive compiled regex objects. This change reduces the number of times regex compilation is performed, which can be a costly operation. The test files have also been updated to reflect these changes.

Codebase simplification:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR93-R132): Extracted regex compilation logic from `replaceProcess` and `filterProcess` methods in the `Run` method. Adjusted the `replaceProcess` and `filterProcess` methods to directly receive compiled regex objects instead of strings. This reduces the number of times regex compilation is performed. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR93-R132) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL122-R169) [[3]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL169-R192) [[4]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL274-R271)

Test changes:

* [`internal/cli/cli_test.go`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL332-R333): Updated `TestReplaceProcess_replace` and `TestReplaceProcess_noMatch` test methods to pass compiled regex objects instead of strings to the `ReplaceProcess` method. [[1]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL332-R333) [[2]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL350-R351)
* [`internal/cli/export_test.go`](diffhunk://#diff-00cc0f11ec46bafc7c5c73ed3d347ca03a5e4c53f376353c9df449523b7f35d5L8-R9): Updated the `ReplaceProcess` method to receive a compiled regex object instead of a string.

Additional changes:

* [`internal/cli/cli_test.go`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR6): Added import statement for the `regexp` package.