### PR TITLE
Update binary name and version template in goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ builds:
     binary: purl
     ldflags:
       - -s -w
-      - -X github.com/catatsuy/purl/cli.Version=v{{.Version}}
+      - -X github.com/catatsuy/purl/internal/cli.Version=v{{.Version}}
     env:
       - CGO_ENABLED=0
     goos:
@@ -17,6 +17,6 @@ builds:
       - amd64
       - arm64
 archives:
-  - name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}'
+  - name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}'
 release:
   prerelease: auto


### PR DESCRIPTION
This pull request includes changes to the `.goreleaser.yml` file. The changes include an update to the `ldflags` field to reflect the new location of the `cli.Version` variable, and a modification to the `name_template` field in the `archives` section to include the project version.

Here are the key changes:

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L10-R10): The `ldflags` field in the `builds` section was updated to `-X github.com/catatsuy/purl/internal/cli.Version=v{{.Version}}` from `-X github.com/catatsuy/purl/cli.Version=v{{.Version}}`, reflecting the new location of the `cli.Version` variable.
* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L20-R20): The `name_template` field in the `archives` section was modified to `'{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}'` from `'{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}'`, to include the project version.