### PR TITLE
Update release archive name template and ldflags path in Makefile

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,6 @@ builds:
       - amd64
       - arm64
 archives:
-  - name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}'
+  - name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}'
 release:
   prerelease: auto

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ go.mod go.sum:
 	go mod tidy
 
 bin/purl: main.go internal/cli/*.go go.mod go.sum
-	go build -ldflags "-X github.com/catatsuy/purl/cli.Version=`git rev-list HEAD -n1`" -o bin/purl main.go
+	go build -ldflags "-X github.com/catatsuy/purl/internal/cli.Version=`git rev-list HEAD -n1`" -o bin/purl main.go
 
 .PHONY: vet
 vet:


### PR DESCRIPTION
This pull request primarily includes changes to the build configuration and the build command in the `Makefile`. The most significant changes involve modifying the name template in the `.goreleaser.yml` file and adjusting the build command in the `Makefile`.

* In the `.goreleaser.yml` file, the `name_template` under `archives` has been modified to exclude the version from the name of the archive file. This change simplifies the naming convention for the generated archive files.

* In the `Makefile`, the build command for `bin/purl` has been updated. The `-ldflags` option now points to `github.com/catatsuy/purl/internal/cli.Version` instead of `github.com/catatsuy/purl/cli.Version`. This change reflects a possible restructuring of the project's directory.