### PR TITLE
Update colorText function to support multiple filters

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -284,11 +284,11 @@ func (c *CLI) filterProcess(filters []*regexp.Regexp, excludes []*regexp.Regexp,
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		hit, hitRe := matchesFilters(line, filters)
+		hit, hitRes := matchesFilters(line, filters)
 		if len(filters) == 0 || hit {
 			if excludeHit, _ := matchesFilters(line, excludes); !excludeHit {
-				if hitRe != nil && c.color {
-					line = colorText(line, hitRe)
+				if len(hitRes) > 0 && c.color {
+					line = colorText(line, hitRes)
 				}
 				fmt.Fprintln(c.outStream, line)
 			}
@@ -317,15 +317,19 @@ func compileRegexps(rawPatterns []string, ignoreCase bool) ([]*regexp.Regexp, er
 	return regexps, nil
 }
 
-func matchesFilters(line string, regexps []*regexp.Regexp) (bool, *regexp.Regexp) {
+func matchesFilters(line string, regexps []*regexp.Regexp) (bool, []*regexp.Regexp) {
+	var matchedRegexps []*regexp.Regexp
 	for _, re := range regexps {
 		if re.MatchString(line) {
-			return true, re
+			matchedRegexps = append(matchedRegexps, re)
 		}
 	}
-	return false, nil
+	return len(matchedRegexps) > 0, matchedRegexps
 }
 
-func colorText(line string, re *regexp.Regexp) string {
-	return re.ReplaceAllString(line, "\x1b[1m\x1b[91m$0\x1b[0m")
+func colorText(line string, res []*regexp.Regexp) string {
+	for _, re := range res {
+		line = re.ReplaceAllString(line, "\x1b[1m\x1b[91m$0\x1b[0m")
+	}
+	return line
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -65,6 +65,11 @@ func TestRun_successProcess(t *testing.T) {
 			input:    "searchb\nreplace\nsearchc",
 			expected: "\x1b[1m\x1b[91msearch\x1b[0mb\n\x1b[1m\x1b[91msearch\x1b[0mc\n",
 		},
+		"color text for multiple filter": {
+			args:     []string{"purl", "-filter", "search", "-filter", "abcd", "-color"},
+			input:    "searchb\nreplace\nsearchcabcdefg",
+			expected: "\x1b[1m\x1b[91msearch\x1b[0mb\n\x1b[1m\x1b[91msearch\x1b[0mc\x1b[1m\x1b[91mabcd\x1b[0mefg\n",
+		},
 		"no color text": {
 			args:     []string{"purl", "-filter", "search", "-no-color"},
 			input:    "searchb\nreplace\nsearchc",


### PR DESCRIPTION
This pull request contains changes to the `internal/cli/cli.go` and `internal/cli/cli_test.go` files. The changes mainly focus on improving the handling of regular expressions in the `matchesFilters` and `colorText` functions, and adding a test case to verify the changes.

Changes to regular expression handling:

* `internal/cli/cli.go` - `func (c *CLI) filterProcess(filters []*regexp.Regexp, excludes []*regexp.Regexp,`: The `hitRe` variable has been renamed to `hitRes` and is now a slice of regular expressions instead of a single regular expression. This allows for multiple matches in the `matchesFilters` function. The `colorText` function has also been updated to handle a slice of regular expressions.

* `internal/cli/cli.go` - `func matchesFilters(line string, regexps []*regexp.Regexp) (bool, []*regexp.Regexp)`: This function now returns a slice of matched regular expressions instead of a single match. This change allows for multiple matches on a single line.

* `internal/cli/cli.go` - `func colorText(line string, res []*regexp.Regexp) string`: This function has been updated to handle a slice of regular expressions. It now colors all matched patterns in the line.

Changes to testing:

* `internal/cli/cli_test.go` - [`func TestRun_successProcess(t *testing.T)`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR68-R72): A new test case "color text for multiple filter" has been added to validate the changes made to the `matchesFilters` and `colorText` functions.