### PR TITLE
Add isStdinTerminal and isStdoutTerminal to NewCLI constructor

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,9 +4,10 @@ import (
 	"os"
 
 	"github.com/catatsuy/purl/internal/cli"
+	"golang.org/x/term"
 )
 
 func main() {
-	c := cli.NewCLI(os.Stdout, os.Stderr, os.Stdin)
+	c := cli.NewCLI(os.Stdout, os.Stderr, os.Stdin, term.IsTerminal(int(os.Stdin.Fd())), term.IsTerminal(int(os.Stdout.Fd())))
 	os.Exit(c.Run(os.Args))
 }


### PR DESCRIPTION
This pull request introduces changes to the `internal/cli/cli.go`, `internal/cli/cli_test.go`, and `main.go` files. The primary goal of these changes is to improve the handling of terminal-related functionalities in the command-line interface (CLI) of the application. This is achieved by adding new fields to the `CLI` struct, modifying the `NewCLI` function, and updating the related tests. 

Here are the key changes in order of importance:

1. **Refactoring of the `CLI` struct and `NewCLI` function**:
   * Two new fields, `isStdinTerminal` and `isStdoutTerminal`, were added to the `CLI` struct to keep track of whether the standard input and output are terminal interfaces.
   * The `NewCLI` function was updated to accept two new parameters corresponding to these new fields. This change was reflected in all the places where `NewCLI` was called [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR51-R68) [[2]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR7-R15) [[3]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL85-R86) [[4]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR101-R205) [[5]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL152-R258) [[6]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL201-R307) [[7]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL261-R367) [[8]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL287-R393) [[9]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL323-R429) [[10]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL334-R440) [[11]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL352-R458) [[12]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL491-R597) [[13]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R7-R11).

2. **Improved handling of color output**:
   * The `color` field in the `CLI` struct was renamed to `isColor` for consistency.
   * The `parseFlags` method was updated to use the `isStdoutTerminal` field when determining whether to color the output.
   * The `filterProcess` method was updated to use the new `isColor` field instead of the old `color` field.

3. **Improved handling of terminal input**:
   * The `parseFlags` and `validateInput` methods were updated to use the `isStdinTerminal` field when parsing flags and validating input [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL207-R214) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL229-R236).

4. **Updated tests**:
   * All tests in the `cli_test.go` file were updated to reflect the changes in the `NewCLI` function and the `CLI` struct [[1]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR7-R15) [[2]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL85-R86) [[3]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR101-R205) [[4]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL152-R258) [[5]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL201-R307) [[6]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL261-R367) [[7]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL287-R393) [[8]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL323-R429) [[9]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL334-R440) [[10]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL352-R458) [[11]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL491-R597).
   * New tests were added to test the behavior of the CLI when the standard input and output are terminal interfaces.

5. **Removal of unused imports**:
   * The `golang.org/x/term` import was removed from `cli.go` as it is no longer needed after the refactoring.
   * The `strings` import was added to `cli_test.go` for the new tests.