### PR TITLE
support multi-line regex replacements

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -76,6 +76,11 @@ func TestRun_successProcess(t *testing.T) {
 			input:    "searchb\nreplace\nsearchc",
 			expected: "searchb\nsearchc\n",
 		},
+		"provide multiple lines for replace": {
+			args:     []string{"purl", "-replace", "@CREATE TABLE `table2`[^;]+@@"},
+			input:    "CREATE TABLE `table1` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;\nCREATE TABLE `table2` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;",
+			expected: "CREATE TABLE `table1` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;\n\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;\n",
+		},
 	}
 
 	for name, test := range tests {
@@ -120,6 +125,10 @@ func TestRun_successProcessOnTerminal(t *testing.T) {
 		"provide multiple files for ignore case": {
 			args:     []string{"purl", "-i", "-replace", "@search@replacement@", "testdata/test.txt", "testdata/testa.txt"},
 			expected: "replacementa replacementb\nreplacementa replacementb\nreplacementc replacementd\nnot not not\n",
+		},
+		"provide multiple lines for replace": {
+			args:     []string{"purl", "-replace", "@CREATE TABLE `table2`[^;]+;@@", "testdata/testsql.txt"},
+			expected: "CREATE TABLE `table1` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;\n\n\n",
 		},
 		"provide multiple files for filter": {
 			args:     []string{"purl", "-filter", "search", "testdata/test.txt", "testdata/testa.txt"},

--- a/internal/cli/testdata/testsql.txt
+++ b/internal/cli/testdata/testsql.txt
@@ -1,0 +1,14 @@
+CREATE TABLE `table1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`id`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE `table2` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `email` varchar(255) NOT NULL,
+  `phone` varchar(255) NOT NULL,
+  `address` varchar(255) NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;


### PR DESCRIPTION
This pull request primarily focuses on enhancing the `replaceProcess` function in the `internal/cli/cli.go` file and updating the corresponding test cases in `internal/cli/cli_test.go`. The changes allow the `replaceProcess` function to handle both terminal and file inputs differently, thereby improving its overall functionality. Additionally, a new test file `internal/cli/testdata/testsql.txt` has been added to aid in the testing process.

Here are the key changes, grouped by theme:

**Improvements to `replaceProcess` function:**

- [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR267-R281): The `replaceProcess` function now checks whether the input is from a terminal or a file. If it's from a terminal, it reads all data at once, performs the regex replacement, and writes the modified data to the output stream. If it's from a file, it processes the input line by line. This enhancement improves the function's ability to handle different types of inputs. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR267-R281) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR293)

**Updates to test cases:**

- [`internal/cli/cli_test.go`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR79-R83): New test cases have been added to both `TestRun_successProcess` and `TestRun_successProcessOnTerminal` functions. These test cases provide multiple lines for replacement, thereby ensuring the `replaceProcess` function correctly handles such scenarios. [[1]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR79-R83) [[2]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR129-R132)

**Addition of new test file:**

- [`internal/cli/testdata/testsql.txt`](diffhunk://#diff-6396c8a6b24494e58adff16a5d32d74860c4f9f4d5f5cedf021f10d9a078574aR1-R14): This new test file contains SQL commands for creating tables. It is used in the new test cases to test the `replaceProcess` function's ability to handle multiple lines for replacement.