### PR TITLE
Improve line-by-line processing to handle CRLF files

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -92,7 +92,7 @@ func (c *CLI) Run(args []string) int {
 	}
 
 	var searchRe *regexp.Regexp
-	var replacement string
+	var replacement []byte
 
 	if len(c.replaceExpr) > 0 {
 		delimiter := string(c.replaceExpr[0])
@@ -102,7 +102,7 @@ func (c *CLI) Run(args []string) int {
 			return ExitCodeFail
 		}
 		var searchPattern string
-		searchPattern, replacement = parts[0], parts[1]
+		searchPattern, replacement = parts[0], []byte(parts[1])
 
 		if c.ignoreCase {
 			searchPattern = "(?i)" + searchPattern
@@ -268,7 +268,7 @@ func (c *CLI) validateInput(flags *flag.FlagSet) error {
 // and writes the modified data to outputStream.
 // If input is from a pipe, it processes input line by line without changing newline characters.
 // If input is from a file, it reads and processes the entire file at once.
-func (c *CLI) replaceProcess(searchRe *regexp.Regexp, replacement string, inputStream io.Reader) error {
+func (c *CLI) replaceProcess(searchRe *regexp.Regexp, replacement []byte, inputStream io.Reader) error {
 	if c.isStdinTerminal {
 		// Read all data from the file input
 		b, err := io.ReadAll(inputStream)
@@ -276,7 +276,7 @@ func (c *CLI) replaceProcess(searchRe *regexp.Regexp, replacement string, inputS
 			return fmt.Errorf("error reading file: %w", err)
 		}
 
-		modified := searchRe.ReplaceAll(b, []byte(replacement))
+		modified := searchRe.ReplaceAll(b, replacement)
 		c.outStream.Write(modified)
 	} else {
 		// Read input line by line when input is from a pipe without changing newline characters
@@ -290,7 +290,7 @@ func (c *CLI) replaceProcess(searchRe *regexp.Regexp, replacement string, inputS
 				return fmt.Errorf("error reading input: %w", err)
 			}
 			// Replace text in each line using the regex
-			modifiedLine := searchRe.ReplaceAll(line, []byte(replacement))
+			modifiedLine := searchRe.ReplaceAll(line, replacement)
 			// Write the changed line to the output
 			if _, err := c.outStream.Write(modifiedLine); err != nil {
 				return fmt.Errorf("error writing to output: %w", err)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -28,12 +28,12 @@ func TestRun_successProcess(t *testing.T) {
 	}{
 		"normal": {
 			args:     []string{"purl", "-replace", "@search@replacement@"},
-			input:    "searchb searchc",
+			input:    "searchb searchc\n",
 			expected: "replacementb replacementc\n",
 		},
 		"no match": {
 			args:     []string{"purl", "-replace", "@search@replacement@"},
-			input:    "no match",
+			input:    "no match\n",
 			expected: "no match\n",
 		},
 		"provide file": {
@@ -73,13 +73,18 @@ func TestRun_successProcess(t *testing.T) {
 		},
 		"no color text": {
 			args:     []string{"purl", "-filter", "search", "-no-color"},
-			input:    "searchb\nreplace\nsearchc",
+			input:    "searchb\nreplace\nsearchc\n",
 			expected: "searchb\nsearchc\n",
 		},
 		"provide multiple lines for replace": {
 			args:     []string{"purl", "-replace", "@CREATE TABLE `table2`[^;]+@@"},
-			input:    "CREATE TABLE `table1` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;\nCREATE TABLE `table2` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;",
-			expected: "CREATE TABLE `table1` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;\n\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;\n",
+			input:    "CREATE TABLE `table1` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;\nCREATE TABLE `table2` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;\n",
+			expected: "CREATE TABLE `table1` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;\n",
+		},
+		"provide CRLF text": {
+			args:     []string{"purl", "-replace", "@search@replacement@"},
+			input:    "searcha search\r\nsearchc searchd\r\n",
+			expected: "replacementa replacement\r\nreplacementc replacementd\r\n",
 		},
 	}
 
@@ -448,7 +453,7 @@ func TestReplaceProcess_replace(t *testing.T) {
 	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
 	cl := cli.NewCLI(outStream, errStream, inputStream, false, false)
 
-	inputStream.WriteString("searchb searchc")
+	inputStream.WriteString("searchb searchc\n")
 
 	err := cl.ReplaceProcess(regexp.MustCompile("search"), "replacement", inputStream)
 
@@ -466,7 +471,7 @@ func TestReplaceProcess_noMatch(t *testing.T) {
 	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
 	cl := cli.NewCLI(outStream, errStream, inputStream, false, false)
 
-	inputStream.WriteString("no match")
+	inputStream.WriteString("no match\n")
 
 	err := cl.ReplaceProcess(regexp.MustCompile("search"), "replacement", inputStream)
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -63,12 +63,12 @@ func TestRun_successProcess(t *testing.T) {
 		},
 		"color text": {
 			args:     []string{"purl", "-filter", "search", "-color"},
-			input:    "searchb\nreplace\nsearchc",
+			input:    "searchb\nreplace\nsearchc\n",
 			expected: "\x1b[1m\x1b[91msearch\x1b[0mb\n\x1b[1m\x1b[91msearch\x1b[0mc\n",
 		},
 		"color text for multiple filter": {
 			args:     []string{"purl", "-filter", "search", "-filter", "abcd", "-color"},
-			input:    "searchb\nreplace\nsearchcabcdefg",
+			input:    "searchb\nreplace\nsearchcabcdefg\n",
 			expected: "\x1b[1m\x1b[91msearch\x1b[0mb\n\x1b[1m\x1b[91msearch\x1b[0mc\x1b[1m\x1b[91mabcd\x1b[0mefg\n",
 		},
 		"no color text": {
@@ -81,10 +81,15 @@ func TestRun_successProcess(t *testing.T) {
 			input:    "CREATE TABLE `table1` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;\nCREATE TABLE `table2` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;\n",
 			expected: "CREATE TABLE `table1` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`id`)\n) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;\n",
 		},
-		"provide CRLF text": {
+		"provide CRLF text for replace": {
 			args:     []string{"purl", "-replace", "@search@replacement@"},
 			input:    "searcha search\r\nsearchc searchd\r\n",
 			expected: "replacementa replacement\r\nreplacementc replacementd\r\n",
+		},
+		"provide CRLF text for filter": {
+			args:     []string{"purl", "-filter", "search"},
+			input:    "searchb\r\nreplace\r\nsearchcabcdefg\r\n",
+			expected: "searchb\r\nsearchcabcdefg\r\n",
 		},
 	}
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -460,7 +460,7 @@ func TestReplaceProcess_replace(t *testing.T) {
 
 	inputStream.WriteString("searchb searchc\n")
 
-	err := cl.ReplaceProcess(regexp.MustCompile("search"), "replacement", inputStream)
+	err := cl.ReplaceProcess(regexp.MustCompile("search"), []byte("replacement"), inputStream)
 
 	if err != nil {
 		t.Errorf("Error=%q", err)
@@ -478,7 +478,7 @@ func TestReplaceProcess_noMatch(t *testing.T) {
 
 	inputStream.WriteString("no match\n")
 
-	err := cl.ReplaceProcess(regexp.MustCompile("search"), "replacement", inputStream)
+	err := cl.ReplaceProcess(regexp.MustCompile("search"), []byte("replacement"), inputStream)
 
 	if err != nil {
 		t.Errorf("Error=%q", err)

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 )
 
-func (c *CLI) ReplaceProcess(searchRe *regexp.Regexp, replacement string, inputStream io.Reader) error {
+func (c *CLI) ReplaceProcess(searchRe *regexp.Regexp, replacement []byte, inputStream io.Reader) error {
 	return c.replaceProcess(searchRe, replacement, inputStream)
 }
 

--- a/internal/cli/testdata/test_crlf.txt
+++ b/internal/cli/testdata/test_crlf.txt
@@ -1,0 +1,2 @@
+searcha searchb
+Searcha Searchb


### PR DESCRIPTION
This pull request mainly modifies the `internal/cli/cli.go` file and the corresponding test files to improve the processing of text replacement and filtering. The changes include replacing the `string` type with `[]byte` for the replacement variable and the input lines, modifying the `replaceProcess` and `filterProcess` methods to read input line by line without changing newline characters, and updating the `matchesFilters` and `colorText` functions to work with `[]byte` instead of `string`.

Changes in type and reading method:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL95-R95): Changed the type of the `replacement` variable from `string` to `[]byte` in the `Run` method. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL95-R95) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL105-R105)
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL271-L315): Modified the `replaceProcess` and `filterProcess` methods to read input line by line when input is from a pipe without changing newline characters.

Changes in functions:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL336-R360): Updated the `matchesFilters` and `colorText` functions to work with `[]byte` instead of `string`.

Test changes:

* [`internal/cli/cli_test.go`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL31-R36): Updated the tests to reflect the changes in the `Run` method and the `replaceProcess` function. [[1]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL31-R36) [[2]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL66-R92) [[3]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL451-R463) [[4]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL469-R481)
* [`internal/cli/export_test.go`](diffhunk://#diff-00cc0f11ec46bafc7c5c73ed3d347ca03a5e4c53f376353c9df449523b7f35d5L8-R8): Updated the exported `ReplaceProcess` function to reflect the changes in the `replaceProcess` function.
* [`internal/cli/testdata/test_crlf.txt`](diffhunk://#diff-c759a7cddf15e2ab6fac57d98e5387c14dc2e02f369929f106e0671569173a80R1-R2): Added a new test file to test the handling of CRLF text.