### PR TITLE
Update branch name from master to main in workflow files

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: ["master"]
+    branches: ["main"]
   schedule:
     - cron: "23 0 * * 6"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,7 +3,7 @@ name: govulncheck
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   schedule:
     - cron: "0 0 * * *"


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows `codeql.yml` and `security.yml`. The changes involve updating the branch references from `master` to `main` in these workflow files.

Branch reference updates:

* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L16-R19): Updated branch references from `master` to `main` in the `push` and `pull_request` sections.
* [`.github/workflows/security.yml`](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL6-R6): Updated the branch reference from `master` to `main` in the `push` section.