### PR TITLE
Update renovate config for updating Go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.22.4
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,16 @@
       "matchStrings": [
         "go-version-input: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
       ]
+    },
+    {
+      "fileMatch": [
+        ".github/workflows/release.yml"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang",
+      "matchStrings": [
+        "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+      ]
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
This pull request primarily focuses on updating the Go version and adding a new file match in the Renovate configuration file. The Go version in the GitHub workflow file has been updated to a specific version, and a new file match has been added to the Renovate configuration file to keep the Go version updated in the GitHub workflow file.

Here are the key changes:

Go version update:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L15-R15): The Go version used in the setup has been updated from `1.22.x` to a specific version `1.22.4`. This ensures that the workflow uses a specific version of Go, providing more control and predictability over the build environment.

Renovate configuration update:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R15-R24): A new file match has been added to the Renovate configuration. This new match targets the `.github/workflows/release.yml` file, and is configured to update the Go version in this file when a new version is available. This ensures that the Go version used in the GitHub workflow is always up to date.