### PR TITLE
Add fail mode to exit with non-zero status if no matches found

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -175,10 +175,15 @@ func (c *CLI) Run(args []string) int {
 			}
 
 			if len(c.filters) > 0 || len(c.excludes) > 0 {
-				err = c.filterProcess(filterRes, excludeRes, file)
+				matched, err := c.filterProcess(filterRes, excludeRes, file)
 				if err != nil {
 					fmt.Fprintf(c.errStream, "Failed to process files: %s\n", err)
 					return ExitCodeFail
+				}
+
+				if c.failMode && !matched {
+					fmt.Fprintf(c.errStream, "No matches found in file: %s\n", filePath)
+					return ExitCodeNoMatch
 				}
 			}
 
@@ -204,10 +209,15 @@ func (c *CLI) Run(args []string) int {
 		}
 
 		if len(c.filters) > 0 || len(c.excludes) > 0 {
-			err = c.filterProcess(filterRes, excludeRes, c.inputStream)
+			matched, err := c.filterProcess(filterRes, excludeRes, c.inputStream)
 			if err != nil {
 				fmt.Fprintf(c.errStream, "Failed to process files: %s\n", err)
 				return ExitCodeFail
+			}
+
+			if c.failMode && !matched {
+				fmt.Fprintln(c.errStream, "No matches found in input")
+				return ExitCodeNoMatch
 			}
 		}
 	}
@@ -324,7 +334,8 @@ func (c *CLI) replaceProcess(searchRe *regexp.Regexp, replacement []byte, inputS
 	return matched, nil
 }
 
-func (c *CLI) filterProcess(filters []*regexp.Regexp, excludes []*regexp.Regexp, inputStream io.Reader) error {
+func (c *CLI) filterProcess(filters []*regexp.Regexp, excludes []*regexp.Regexp, inputStream io.Reader) (bool, error) {
+	matched := false
 	// Read input line by line when input is from a pipe without changing newline characters
 	reader := bufio.NewReader(inputStream)
 	for {
@@ -333,24 +344,25 @@ func (c *CLI) filterProcess(filters []*regexp.Regexp, excludes []*regexp.Regexp,
 			if err == io.EOF {
 				break
 			}
-			return fmt.Errorf("error reading input: %w", err)
+			return false, fmt.Errorf("error reading input: %w", err)
 		}
 
 		hit, hitRes := matchesFilters(line, filters)
 		if len(filters) == 0 || hit {
+			matched = hit
 			if excludeHit, _ := matchesFilters(line, excludes); !excludeHit {
 				if len(hitRes) > 0 && c.isColor {
 					line = colorText(line, hitRes)
 				}
 
 				if _, err := c.outStream.Write(line); err != nil {
-					return fmt.Errorf("error writing to output: %w", err)
+					return false, fmt.Errorf("error writing to output: %w", err)
 				}
 			}
 		}
 	}
 
-	return nil
+	return matched, nil
 }
 
 func compileRegexps(rawPatterns []string, ignoreCase bool) ([]*regexp.Regexp, error) {

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 )
 
-func (c *CLI) ReplaceProcess(searchRe *regexp.Regexp, replacement []byte, inputStream io.Reader) error {
+func (c *CLI) ReplaceProcess(searchRe *regexp.Regexp, replacement []byte, inputStream io.Reader) (bool, error) {
 	return c.replaceProcess(searchRe, replacement, inputStream)
 }
 

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -9,7 +9,7 @@ func (c *CLI) ReplaceProcess(searchRe *regexp.Regexp, replacement []byte, inputS
 	return c.replaceProcess(searchRe, replacement, inputStream)
 }
 
-func (c *CLI) FilterProcess(filters []*regexp.Regexp, notFilters []*regexp.Regexp, inputStream io.Reader) error {
+func (c *CLI) FilterProcess(filters []*regexp.Regexp, notFilters []*regexp.Regexp, inputStream io.Reader) (bool, error) {
 	return c.filterProcess(filters, notFilters, inputStream)
 }
 


### PR DESCRIPTION
This pull request introduces a new `failMode` feature to the CLI tool, which ensures the program exits with a specific status code if no matches are found during a replace operation. It also adjusts the exit codes for various error scenarios. 

Key changes include:

### New Feature: `failMode`

* Added `failMode` boolean flag to the `CLI` struct and its associated command-line flag. (`internal/cli/cli.go`) [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR63) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR231)
* Updated the `replaceProcess` method to return a boolean indicating whether any matches were found. (`internal/cli/cli.go`) [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL271-R298) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL290-R323)
* Modified the `Run` method to check the `failMode` flag and exit with a new `ExitCodeNoMatch` if no matches are found. (`internal/cli/cli.go`) [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL163-R174) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL186-R203)

### Exit Code Adjustments

* Changed the exit codes for `ExitCodeParseFlagError` and `ExitCodeFail` to 2, and introduced `ExitCodeNoMatch` with a value of 1. (`internal/cli/cli.go`)

### Test Updates

* Updated existing tests and added new tests to cover the `failMode` feature and adjusted exit codes. (`internal/cli/cli_test.go`) [[1]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR127-R130) [[2]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR178-R217) [[3]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL213-R229) [[4]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR271-R275) [[5]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL363-R398) [[6]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL404-R424) [[7]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL430-R460) [[8]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL463-R491)
* Modified the `ReplaceProcess` method in the test export file to match the new signature. (`internal/cli/export_test.go`)