### PR TITLE
Handle edge cases for input without final newline in CLI processing

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -31,6 +31,11 @@ func TestRun_successProcess(t *testing.T) {
 			input:    "searchb searchc\n",
 			expected: "replacementb replacementc\n",
 		},
+		"normal no last LF": {
+			args:     []string{"purl", "-replace", "@search@replacement@"},
+			input:    "searchb searchc",
+			expected: "replacementb replacementc",
+		},
 		"no match": {
 			args:     []string{"purl", "-replace", "@search@replacement@"},
 			input:    "no match\n",
@@ -85,6 +90,16 @@ func TestRun_successProcess(t *testing.T) {
 			args:     []string{"purl", "-filter", "search", "-fail"},
 			input:    "searchb\r\nreplace\r\nsearchcabcdefg\r\n",
 			expected: "searchb\r\nsearchcabcdefg\r\n",
+		},
+		"provide no LF text": {
+			args:     []string{"purl", "-filter", "search"},
+			input:    "searchb",
+			expected: "searchb",
+		},
+		"provide no match and no LF text": {
+			args:     []string{"purl", "-filter", "search"},
+			input:    "aaaab",
+			expected: "",
 		},
 		"provide CRLF text for replace": {
 			args:     []string{"purl", "-replace", "@search@replacement@"},


### PR DESCRIPTION
This pull request enhances the handling of input data processing and improves test coverage in the `internal/cli/cli.go` file. The most important changes include processing remaining data when the end of the file is reached and adding new test cases to cover these scenarios.

### Enhancements to Input Data Processing:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR317-R326): Added logic to process the remaining data when the end of the file is reached in the `replaceProcess` and `filterProcess` functions. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR317-R326) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR355-R370)

### Improvements to Test Coverage:

* [`internal/cli/cli_test.go`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR34-R38): Added new test cases to ensure that the `replaceProcess` and `filterProcess` functions handle input without a trailing newline correctly. [[1]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR34-R38) [[2]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR94-R103)