### PR TITLE
Add unescapeString function for handling special character replacements

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -111,6 +111,56 @@ func TestRun_successProcess(t *testing.T) {
 			input:    "searchb\r\nreplace\r\nsearchcabcdefg\r\n",
 			expected: "searchb\r\nsearchcabcdefg\r\n",
 		},
+		"replace with special characters": {
+			args:     []string{"purl", "-replace", "@search@re\\nplace@"},
+			input:    "searchb searchc\n",
+			expected: "re\nplaceb re\nplacec\n",
+		},
+		"replace with literal backslash": {
+			args:     []string{"purl", "-replace", "@search@re\\\\place@"},
+			input:    "searchb searchc\n",
+			expected: "re\\placeb re\\placec\n",
+		},
+		"replace with tab character": {
+			args:     []string{"purl", "-replace", "@search@re\\tplace@"},
+			input:    "searchb searchc\n",
+			expected: "re\tplaceb re\tplacec\n",
+		},
+		"replace tab with space": {
+			args:     []string{"purl", "-replace", "@\\t@ @"},
+			input:    "column1\tcolumn2\tcolumn3\n",
+			expected: "column1 column2 column3\n",
+		},
+		"filter lines containing tab": {
+			args:     []string{"purl", "-filter", "\t"},
+			input:    "row1\tdata1\nrow2 data2\nrow3\tdata3\n",
+			expected: "row1\tdata1\nrow3\tdata3\n",
+		},
+		"replace tab with new line": {
+			args:     []string{"purl", "-replace", "@\t@\\n@"},
+			input:    "row1\tdata1\tdata2\n",
+			expected: "row1\ndata1\ndata2\n",
+		},
+		"replace with carriage return": {
+			args:     []string{"purl", "-replace", "@search@re\rplace@"},
+			input:    "searchb searchc\n",
+			expected: "re\rplaceb re\rplacec\n",
+		},
+		"replace carriage return with space": {
+			args:     []string{"purl", "-replace", "@\r@ @"},
+			input:    "line1\rline2\rline3\n",
+			expected: "line1 line2 line3\n",
+		},
+		"filter lines containing carriage return": {
+			args:     []string{"purl", "-filter", "\r"},
+			input:    "line1\rdata1\nline2 data2\nline3\rdata3\n",
+			expected: "line1\rdata1\nline3\rdata3\n",
+		},
+		"replace carriage return with new line": {
+			args:     []string{"purl", "-replace", "@\r@\\n@"},
+			input:    "row1\rdata1\rdata2\n",
+			expected: "row1\ndata1\ndata2\n",
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
This pull request introduces a new utility function to unescape special characters in replacement strings and adds several test cases to ensure its functionality. The key changes include the addition of a new import, the implementation of the `unescapeString` function, its integration into the `Run` method, and the inclusion of new test cases.

### Key Changes:

**Code Enhancements:**
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR12): Added `strings` package to handle string replacements.
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR74-R83): Implemented `unescapeString` function to convert escaped sequences like `\n`, `\t`, and `\r` to their actual characters.
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL106-R119): Integrated `unescapeString` into the `Run` method to process replacement strings.

**Testing:**
* [`internal/cli/cli_test.go`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR114-R163): Added multiple test cases to verify the correct handling of special characters, including newlines, tabs, and carriage returns in replacement strings.