### PR TITLE
Add extract feature to CLI for regex-based text extraction and printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ https://github.com/catatsuy/purl/assets/1249910/5cc479cc-ce1c-4901-864d-963bf659
 **purl** is a tool that helps you easily handle data from different sources. Here are its main features:
 
 - **Flexible Data Input and Output**: You can input data from typing directly or from files. Similarly, you can choose to output data directly to your screen or save it back to files.
-- **Simple Commands**: Use straightforward options like `-replace`, `-filter`, and `-exclude` to manage your data.
+- **Extract Specific Text**: The `-extract` option lets you extract and format specific parts of the text using regular expressions. For example, you can capture groups in the pattern and use them in a custom output format.
+- **Simple Commands**: Use straightforward options like `-replace`, `-filter`, `-exclude`, and `-extract` to manage your data.
 - **Edit Files Easily**: The `-overwrite` option lets you update files directly, making changes quick and simple.
 - **Colorful Output**: When using the `-filter` option, the output on your screen can be colorful. You can control this with the `-color` or `-no-color` options.
-- **Error on No Matches**: With the `-fail` option, Purl returns an error (status code 1) if no matches are found when using `-filter` or `-replace`, similar to grep. If not used, Purl will not return an error even if no matches are found.
+- **Error on No Matches**: With the `-fail` option, Purl returns an error (status code 1) if no matches are found when using `-filter`, `-replace`, or `-extract`. If not used, Purl will not return an error even if no matches are found.
 
 This tool is made to be user-friendly and effective for different data handling tasks.
 
@@ -135,6 +136,48 @@ purl -filter "error" yourlog.log
 ```
 
 This command filters the lines containing "error" in `yourlog.log`, displaying them with colored output for better visibility.
+
+### Extracting Specific Parts of Text
+
+The `-extract` option allows you to capture specific parts of the text using regular expressions and output them in a custom format.
+
+```bash
+purl -extract "@quick ([a-z]+) fox@animal: $1@" yourfile.txt
+```
+
+This command captures the word after "quick" and before "fox" and formats it as `animal: <captured_word>`. For example, given the input:
+
+```
+The quick brown fox jumps over the lazy dog
+quick red fox
+```
+
+The output will be:
+
+```
+animal: brown
+animal: red
+```
+
+You can also use multiple capture groups to format more complex outputs:
+
+```bash
+purl -extract "@(\\w+) (\\w+) (\\w+)@Match: $1, $2, $3@" yourfile.txt
+```
+
+With the input:
+
+```
+apple banana cherry
+grape orange pineapple
+```
+
+The output will be:
+
+```
+Match: apple, banana, cherry
+Match: grape, orange, pineapple
+```
 
 ### Using the `-fail` Option
 

--- a/internal/cli/testdata/test_extract.txt
+++ b/internal/cli/testdata/test_extract.txt
@@ -1,0 +1,2 @@
+The quick brown fox jumps over the lazy dog
+A quick red fox jumps over the sleepy cat

--- a/internal/cli/testdata/test_extract2.txt
+++ b/internal/cli/testdata/test_extract2.txt
@@ -1,0 +1,2 @@
+Another quick green fox leaps over the energetic rabbit
+Yet another quick blue fox hops over the curious turtle


### PR DESCRIPTION
This pull request introduces a new `-extract` feature to the CLI tool, allowing users to extract and print text matching a given regex pattern. The most important changes include modifications to the CLI struct, the addition of the extract logic, and updates to the validation and testing processes.

### New Feature: Extract Option

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR62): Added `extractExpr` to the `CLI` struct and implemented the logic to handle the `-extract` option, including regex compilation, file processing, and standard input processing. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR62) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR239-R303) [[3]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR315)

### Validation Enhancements

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL282-R394): Added new methods `validateMutuallyExclusiveOptions` and `validateExpressionFormats` to ensure that incompatible options are not used together and that expression formats are valid.

### Testing Updates

* [`internal/cli/cli_test.go`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR164-R186): Added test cases to cover various scenarios for the `-extract` option, including basic extraction, multiple capture groups, and file processing.
* `internal/cli/testdata/test_extract.txt` and `internal/cli/testdata/test_extract2.txt`: Added test data files to support the new test cases. [[1]](diffhunk://#diff-0c75a5b4d1f6d282eac52bf574fc9846910353de1c4dc3bbd3bb805fb6804afbR1-R2) [[2]](diffhunk://#diff-2fffcd2490c7a2ec781fae3add7012382cb493f5566b462d7cc433412912fc01R1-R2)