### PR TITLE
Update regex patterns to support multi-line mode in CLI and add tests.

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -513,7 +513,9 @@ func compileRegexps(rawPatterns []string, ignoreCase bool) ([]*regexp.Regexp, er
 	regexps := make([]*regexp.Regexp, 0, len(rawPatterns))
 	for _, pattern := range rawPatterns {
 		if ignoreCase {
-			pattern = "(?i)" + pattern
+			pattern = "(?im)" + pattern
+		} else {
+			pattern = "(?m)" + pattern
 		}
 		re, err := regexp.Compile(pattern)
 		if err != nil {


### PR DESCRIPTION
This pull request introduces changes to support multi-line mode in the `compileRegexps` function and adds corresponding tests to ensure the new functionality works as expected.

### Changes to regex compilation:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL516-R518): Modified the `compileRegexps` function to include the `m` flag for multi-line mode when compiling regular expressions. This change ensures that the regexes are treated as multi-line patterns.

### Additions to test cases:

* [`internal/cli/cli_test.go`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR880-R944): Added a new test function `TestRun_MultiLineMode` to cover various scenarios for the multi-line mode. This includes tests for excluding empty lines, lines with only spaces, lines starting with a specific character, filtering lines starting with a specific word, filtering lines containing a word, and replacing specific lines or words in multiple lines.