### PR TITLE
Add line mode to CLI for processing input line by line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,28 @@ https://github.com/catatsuy/purl/assets/1249910/5cc479cc-ce1c-4901-864d-963bf659
 
 This tool is made to be user-friendly and effective for different data handling tasks.
 
+## Input Processing Modes
+
+Purl has two ways to read input:
+
+1. **Multi-Line Mode (For Files)**
+   When you use a file, purl reads the whole file at once. This lets you use regular expressions that match across multiple lines. However, it waits until the file is finished, so it is not good for live data (like piped input).
+
+2. **Line Mode (For Standard Input)**
+   When you do not give a file (using standard input), purl automatically uses **line mode**. In this mode, purl reads one line at a time and prints the output immediately. You can also force this mode by using the `-line` option.
+
+   **Examples:**
+   - To process data from a file or pipe and force line-by-line reading:
+     ```bash
+     cat yourfile.txt | purl -line -replace "@search@replace@"
+     ```
+   - If no file is given, purl uses line mode by default so it does not wait forever:
+     ```bash
+     purl -line -filter "error"
+     ```
+
+This way, purl outputs data quickly when reading live input, and still supports multi-line matching when reading files.
+
 ### Regular Expressions and Multi-Line Mode in Purl
 
 Purl uses Go's `regexp` package with **Multi-Line Mode** (`(?m)`) always enabled. This makes line-based text processing intuitive and powerful.


### PR DESCRIPTION
This pull request introduces a new input processing mode to the `purl` tool, allowing it to handle data on a line-by-line basis. The changes include updates to the documentation, the command-line interface, and the test cases to support this new mode.

### Documentation Updates:
* Added a new section "Input Processing Modes" to the `README.md` file, explaining the two ways `purl` can read input: Multi-Line Mode for files and Line Mode for standard input.

### Command-Line Interface Updates:
* Introduced a new `lineMode` flag to the `CLI` struct in `internal/cli/cli.go`.
* Updated the `parseFlags` method to handle the new `-line` option and automatically enable line mode when reading from standard input. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR322) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR339-R342)
* Modified the `replaceProcess` and `extractProcess` methods to support line-by-line processing when `lineMode` is enabled. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL406-R412) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR491-R523) [[3]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR547)

### Test Case Updates:
* Added new test cases in `internal/cli/cli_test.go` to verify the functionality of the line mode, including tests for line-by-line replacement and extraction. [[1]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL85-R85) [[2]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL236-L239) [[3]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL916-R912) [[4]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR941-R975)