### PR TITLE
update go version from 1.23.x to 1.24.1 in workflow config

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.x"
+          go-version: "1.24.1"
 
       - name: Build
         run: make


### PR DESCRIPTION
This pull request includes an update to the Go version used in the GitHub Actions workflow. The change updates the Go version from "1.23.x" to "1.24.1" in the `.github/workflows/go.yml` file.

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL21-R21): Updated the Go version from "1.23.x" to "1.24.1" to ensure the workflow uses the latest version.