### PR TITLE
bump Go version to 1.25.0 and remove toolchain directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/catatsuy/purl
 
-go 1.23.0
-
-toolchain go1.25.1
+go 1.25.0
 
 require golang.org/x/term v0.34.0
 


### PR DESCRIPTION
This pull request makes a minor update to the Go toolchain version in the `go.mod` file, aligning the module to use Go 1.25.0 instead of Go 1.23.0 and removing the explicit `toolchain` directive.